### PR TITLE
Update callable test

### DIFF
--- a/source/Renderer.php
+++ b/source/Renderer.php
@@ -648,7 +648,7 @@ class Renderer
                 $key = $flippedAttributes[$properKey];
             }
 
-            if (is_callable($value)) {
+            if ($value instanceof Closure) {
                 $value = $value();
             }
 


### PR DESCRIPTION
Removed test for callability and changed to test if the value is an instance of `Closure`.

Supposing we are rendering an element like this `<div id={"app"}>Some Content</div>` with Pre.

While testing using `is_callable`, if a function `app` exists in the Global Namespace, `is_callable` will return true and will call that function, hence, won't be able to use the value `app` for `id` or any attribute.